### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3
+
+COPY core /
+COPY lib /
+COPY txt /
+COPY LittleBrother.py /
+COPY requirements.txt /
+COPY settings.py /
+
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT ["python3", "LittleBrother.py"]


### PR DESCRIPTION
This removes the need to have python 3 installed locally.

```
docker build -t LittleBrother
docker run --rm LittleBrother
```